### PR TITLE
Fix issue where user launches the app for the first time with no data

### DIFF
--- a/source/css/_splash.css.scss
+++ b/source/css/_splash.css.scss
@@ -7,4 +7,9 @@
     color: white;
     font-size: 60px;
   }
+
+  .retry-section {
+    @include center-in-parent;
+    top: 80%;
+  }
 }

--- a/source/js/services/configuration_service.coffee
+++ b/source/js/services/configuration_service.coffee
@@ -1,0 +1,8 @@
+class Service
+  constructor: (@$q) ->
+  initialSyncComplete: () => 
+    if window.localStorage['initialSyncComplete'] then true else false
+  initialSyncCompleted: () =>
+    window.localStorage['initialSyncComplete'] = true
+
+angular.module('app').service 'configurationService', ['$q', Service]

--- a/source/js/services/i18n_service.coffee
+++ b/source/js/services/i18n_service.coffee
@@ -38,6 +38,9 @@ EN =
   sessionTitleFailure: 'Oh no!'
   sessionMessageFailure: 'You\'ve run out of chances! Better luck next time!'
   acknowledgeButton: 'Ok'
+  syncFailureOfflineMessage: 'Unable to update content'
+  syncFailureRetryMessage: 'Unable to update content. Check your network connection and retry'
+  syncRetryButtonMessage: 'Retry Sync'
 
 class Service
   constructor: () ->

--- a/source/js/services/sync_service.coffee
+++ b/source/js/services/sync_service.coffee
@@ -1,5 +1,5 @@
 class Service
-  constructor: (@$http, @$q, @BACKEND_URL, @categoryService, @entryService, @imageCreditService, @downloadService) ->
+  constructor: (@$http, @$q, @BACKEND_URL, @configurationService, @categoryService, @entryService, @imageCreditService, @downloadService) ->
   refresh: () =>
     deferred = @$q.defer()
     @$http.get("#{@BACKEND_URL}/api/sync/all")
@@ -15,10 +15,11 @@ class Service
               @entryService.save e
               @downloadService.saveAssetsForEntry e
             @imageCreditService.store res.data.image_credits
+            @configurationService.initialSyncCompleted()
             deferred.resolve()
           , (err) =>
             deferred.reject()  
 
     return deferred.promise
 
-angular.module('app').service 'syncService', ['$http', '$q', 'BACKEND_URL', 'categoryService', 'entryService', 'imageCreditService', 'downloadService', Service]
+angular.module('app').service 'syncService', ['$http', '$q', 'BACKEND_URL', 'configurationService', 'categoryService', 'entryService', 'imageCreditService', 'downloadService', Service]

--- a/source/partials/_splash.haml
+++ b/source/partials/_splash.haml
@@ -1,2 +1,5 @@
 .splash
   .name JILA
+
+  %div.retry-section{ng: {if: 'retryAvailable'}}
+    %button{ng: {click: 'retrySync()'}} {{ retryButtonMessage }}


### PR DESCRIPTION
This change shows a retry button on the splash screen and prevents further progress if the user launches the app without network connectivity and doesn't have an existing data set.